### PR TITLE
Feat/animate homepage on initial

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,10 +8,10 @@
   </head>
   <body>
     <!-- background opacity wrapper -->
-    <div class="animate-overlay-on-load flex justify-center items-center w-full min-h-screen p-10 font-general text-white bg-black/75">
+    <div class="animate-overlay-on-load flex justify-center items-center w-full min-h-screen p-10 font-general text-white bg-black/50">
 
     <!-- main container (specify dimiensions to keep it centered for typing!) -->
-    <section class="flex flex-col gap-5 w-screen max-w-md h-screen max-h-80 text-left">
+    <section class="flex flex-col gap-7 w-screen max-w-md h-screen max-h-80 text-left">
       <h1 class="type-me">hi, welcome to my sandbox!</h1>
       <!-- main content -->
       <div class="flex flex-col gap-5">
@@ -44,8 +44,8 @@
             />link
           </a>
         </nav>
-        <a href="#" class="text-sm hover:underline type-me">@frantaing</a>
       </div>
+      <a href="#" class="text-sm hover:underline type-me">@frantaing</a>
     </section>
 
   

--- a/src/main.js
+++ b/src/main.js
@@ -25,43 +25,49 @@ document.addEventListener("DOMContentLoaded", () => {
 
   // 2. FUNCTION: handle typing for one item in queue
   const typeText = (item, options = {}) => {
-    const { typingSpeed = 10, keepCursor = false } = options; // typing speed here!
-
+    const { typingSpeed = 10, keepCursor = false, preTypingDelay = 0 } = options; // typing speed here!
     return new Promise(resolve => {
-      let i = 0;
-      // add cursor to parent element
+      // add cursor immediately so it blinks during the delay
       item.element.classList.add("typing-cursor");
 
-      const typingInterval = setInterval(() => {
-        if (i < item.text.length) {
-          // append character to the specific text node
-          item.node.textContent += item.text.charAt(i);
-          i++;
-        } else {
-          clearInterval(typingInterval);
-          // if not the last element, remove the cursor
-          if (!keepCursor) {
-            item.element.classList.remove("typing-cursor");
+      // create a delay before typing starts
+      setTimeout(() => {
+        const typingInterval = setInterval(() => {
+          if (i < item.text.length) {
+            item.node.textContent += item.text.charAt(i);
+            i++;
+          } else {
+            clearInterval(typingInterval);
+            if (!keepCursor) {
+              item.element.classList.remove("typing-cursor");
+            }
+            resolve();
           }
-          resolve(); // animation is done!
-        }
-      }, typingSpeed);
+        }, typingSpeed);
+      }, preTypingDelay); // delay value
+      let i = 0;
     });
   };
   // 3. ASYNCH FUNCTION: run animations in sequence
   const runAnimations = async () => {
+    const initialBlinkDelay = 1700; // set delay here (miliseconds)
+
     for (let i = 0; i < animationQueue.length; i++) {
-      // small delay before starting the next line
       if (i > 0) {
         await new Promise(resolve => setTimeout(resolve, 200));
       }
       
+      const isFirstElement = i === 0;
       const isLastElement = i === animationQueue.length - 1;
-      await typeText(animationQueue[i], { keepCursor: isLastElement });
+
+      // pass initial delay only for the first element
+      const options = {
+        keepCursor: isLastElement,
+        preTypingDelay: isFirstElement ? initialBlinkDelay : 0
+      };
+
+      await typeText(animationQueue[i], options);
     }
   };
-  // delay
-  setTimeout(() => {
-    runAnimations(); // start animation
-  }, 500);
+  runAnimations(); // start animation
 });

--- a/src/style.css
+++ b/src/style.css
@@ -21,7 +21,7 @@
     .typing-cursor::after {
         content: '_';
         color: inherit; /* inherit parent color */ 
-        animation: blink 1s step-end infinite;
+        animation: blink 0.7s step-end infinite;
     }
     @keyframes blink {
         from, to { color: transparent; /* make the cursor transparent */ }


### PR DESCRIPTION
## Description

Adds animation to the homepage!
The background will now slowly fade in from black to the background-image, and the text will be displayed through a blinking cursor/typing animation. Kind of playing into that game-y feel.

## What's Changed

- **The Background**:
  - The background-image will now slowly fade in on load through the use of CSS `@keyframes` and a new CSS class, `.animate-overlay-on-load` (`powerOn`) in `style.css`. The new class is applied to the `<div>` overlay in `index.html`.
- **The Blinking Cursor**:
  - On page load, there is only a blinking ("`_`") cursor for a few around a second, before it starts typing out the homepage's contents. This is done in `main.js`, where you can change specifics like how long the delay before typing and typing speed. The cursor itself can also be changed through `style.css`, using `@keyframes` where the cursor symbol and time intervals between cursor blinks can be modified.
- **Two Separate `@layer` groups**:
  - There are now two `@layer utility` blocks: one with your usual CSS styling and classes, and the other holds all `@keyframes`. 

## Screenshot
> Yes, the quality is bad :frowning_face:

![Untitled design](https://github.com/user-attachments/assets/567da732-321a-4711-8b5c-530035379960)

## Follow Up
- Change the background :upside_down_face: 