### PR TITLE
style: use hover/focus styling for active links in NavBar

### DIFF
--- a/src/lib/components/receipted/NavBar.svelte
+++ b/src/lib/components/receipted/NavBar.svelte
@@ -1,14 +1,30 @@
+<script lang="ts">
+    // for active links
+    import { page } from '$app/state';
+</script>
+
 <nav class="z-50 fixed top-0 left-0 w-full bg-black text-white font-[monospace] font-bold text-lg">
     <div class="mx-auto flex justify-between items-center w-full max-w-xl py-5 px-16 sm:px-0">
         <div>
-            <a href="/receipted">RECEIPTED</a>
+            <a 
+                href="/receipted" 
+                class:active={page.url.pathname === '/receipted'}
+            >RECEIPTED</a>
         </div>
         <div>
-            <a href="/receipted/gallery" class="lowercase">gallery</a> 
-            <a href="/receipted/about" class="lowercase">about</a>
+            <a 
+                href="/receipted/gallery" 
+                class="lowercase"
+                class:active={page.url.pathname === '/receipted/gallery'}
+            >gallery</a> 
+            <a 
+                href="/receipted/about" 
+                class="lowercase"
+                class:active={page.url.pathname === '/receipted/about'}
+            >about</a>
+            <!-- no need for active styling on HOME link -->
             <a href="/concepts" class="uppercase">HOME</a>
         </div>
-        
     </div>
 </nav>
 
@@ -16,7 +32,7 @@
 <div class="h-28"></div>
 
 <style>
-    a{
+    a {
         text-decoration: none;
         color:white;
         text-align:center;
@@ -24,12 +40,7 @@
         box-shadow: inset 0 -1px 0 0 yellow;
         transition: color .2s ease-in-out, box-shadow .2s ease-in-out;
     }
-    a:hover{
-        color:black;
-        box-shadow: inset 0 -100px 0 0 yellow;
-    }
-    a:focus{
-        color:black;
-        box-shadow: inset 0 -100px 0 0 yellow;
+    a:hover, a:focus, a.active {
+        color:black;        box-shadow: inset 0 -100px 0 0 yellow;
     }
 </style>


### PR DESCRIPTION
In `Receipted`, `NavBar` links that are active ("RECEIPTED", "about", and "gallery") should now be highlighted when it's active.

## What's changed?
- **Active links for `Receipted`**:
  - Active links in `Receipted`'s `NavBar` should now use the hover styles when it is active (e.g. if you're on the homepage, "RECEIPTED" should be fully highlighted in yellow).

## Look 👀
<img width="575" height="56" alt="image" src="https://github.com/user-attachments/assets/eb5bd385-e11c-43b3-abff-e2d16c0d3686" />
