### PR TITLE
feat: add disclaimer to Recreate index

### DIFF
--- a/src/lib/components/Disclaimer.svelte
+++ b/src/lib/components/Disclaimer.svelte
@@ -1,0 +1,44 @@
+<script lang="ts">
+    // Imports
+    import { slide } from 'svelte/transition';
+    import { typewriter } from '$lib/actions/typewriter';
+
+    let isOpen = $state(false);
+</script>
+
+<div class="mt-3 w-full max-w-xl">
+    
+    <!-- Button -->
+    <button 
+        onclick={() => isOpen = !isOpen}
+        class="group flex items-center gap-2 text-xs font-bold text-white/70 hover:text-white transition-colors uppercase"
+    >
+        <!-- [ + ] Button -->
+        <span class="text-yellow-500 flex gap-px">
+            <span use:typewriter={'['}></span>
+            <span>{isOpen ? '-' : '+'}</span>
+            <span use:typewriter={']'}></span>
+        </span>
+
+        <!-- Label -->
+        <span use:typewriter={'RECREATION DISCLAIMER'}></span>
+    </button>
+
+    <!-- Content Area (NOT TYPED) -->
+    {#if isOpen}
+        <div transition:slide={{ duration: 300 }} class="overflow-hidden">
+            <p class="mt-2 text-sm leading-relaxed text-justify">
+                This is a personal, non-commercial project created for educational and recreational purposes only. All text content, links, and branding elements in this project are copied from the original websites for practice purposes. All images, icons, and other media are sourced from free-to-use platforms (e.g., Unsplash, Boxicons) or replaced with placeholders. This project is not affiliated with, endorsed, sponsored, or specifically approved by the original sites. All original code in this repository is licensed under the 
+                <!-- Link inside the paragraph -->
+                <a 
+                    href="https://github.com/frantaing/blasted-glass/blob/main/LICENSE" 
+                    target="_blank"
+                    class="underline hover:text-white transition-colors"
+                >
+                    MIT License.
+                </a>
+            </p>
+        </div>
+    {/if}
+    
+</div>

--- a/src/lib/components/Disclaimer.svelte
+++ b/src/lib/components/Disclaimer.svelte
@@ -6,17 +6,17 @@
     let isOpen = $state(false);
 </script>
 
-<div class="mt-3 w-full max-w-xl">
+<div class="mt-4 w-full max-w-xl">
     
     <!-- Button -->
     <button 
         onclick={() => isOpen = !isOpen}
-        class="group flex items-center gap-2 text-xs font-bold text-white/70 hover:text-white transition-colors uppercase"
+        class="group flex items-center gap-2 text-sm font-bold text-white/70 hover:text-white transition-colors uppercase"
     >
         <!-- [ + ] Button -->
         <span class="text-yellow-500 flex gap-px">
             <span use:typewriter={'['}></span>
-            <span>{isOpen ? '-' : '+'}</span>
+            <span use:typewriter={isOpen ? '-' : '+'}></span>
             <span use:typewriter={']'}></span>
         </span>
 

--- a/src/lib/components/Disclaimer.svelte
+++ b/src/lib/components/Disclaimer.svelte
@@ -3,20 +3,34 @@
     import { slide } from 'svelte/transition';
     import { typewriter } from '$lib/actions/typewriter';
 
+    // [+] ICON
     let isOpen = $state(false);
+    // Track if button has been clicked yet
+    let hasInteracted = $state(false);
+    function toggle() {
+        isOpen = !isOpen;
+        // As soon as button is clicked, switch!
+        hasInteracted = true; 
+    }
 </script>
 
 <div class="mt-4 w-full max-w-xl">
     
     <!-- Button -->
     <button 
-        onclick={() => isOpen = !isOpen}
-        class="group flex items-center gap-2 text-sm font-bold text-white/70 hover:text-white transition-colors uppercase"
+        onclick={toggle}
+        class="group flex items-center gap-2 text-sm font-bold text-white/70 hover:text-white transition-colors uppercase cursor-pointer"
     >
         <!-- [ + ] Button -->
         <span class="text-yellow-500 flex gap-px">
             <span use:typewriter={'['}></span>
-            <span use:typewriter={isOpen ? '-' : '+'}></span>
+            {#if !hasInteracted}
+                <!-- Initial icon -->
+                <span use:typewriter={'+'}></span>
+            {:else}
+                <!-- Change if clicked -->
+                <span>{isOpen ? '-' : '+'}</span>
+            {/if}
             <span use:typewriter={']'}></span>
         </span>
 

--- a/src/routes/(index)/recreates/+page.svelte
+++ b/src/routes/(index)/recreates/+page.svelte
@@ -6,6 +6,7 @@
     import NavLink from '$lib/components/NavLink.svelte';
     import RepoLink from '$lib/components/RepoLink.svelte';
     import SmallLink from '$lib/components/SmallLink.svelte';
+    import Disclaimer from '$lib/components/Disclaimer.svelte';
 </script>
 
 <!-- Heading & Description -->
@@ -15,9 +16,11 @@
         <p>
             <span use:typewriter={"these are recreations of certain websites. the ones grouped below are specific challenges from "}></span>
             <SmallLink href="https://www.frontendpractice.com/" text="frontend practice." />
-        </p>    
+        </p>
+        <Disclaimer />   
     </div>
 </section>
+
 <!-- Navigation -->
 <section class="flex flex-col gap-5">
     <nav class="flex flex-col">


### PR DESCRIPTION
This just adds the disclaimer already present in the README files of the recreates that have their own repo, but it's now included in the Recreate index for recreates built *within* this repo.

## What's changed?
- **Disclaimer**:
  - Added a new component that's just the disclaimer.
  - It's a nice lil button that toggle the display of the disclaimer.

## Look 👀
<img width="453" height="270" alt="image" src="https://github.com/user-attachments/assets/80fbca9b-b594-4f7b-9fb0-a7e94f72e2ab" />
<img width="453" height="513" alt="image" src="https://github.com/user-attachments/assets/6c37cc07-8efe-47f6-b3b7-325b89d5f1b7" />

---

> Closes #24: Added disclaimer to Recreate index